### PR TITLE
chore: Update multi-platform build and publish workflow

### DIFF
--- a/.github/workflows/multi-platform-build-and-publish.yml
+++ b/.github/workflows/multi-platform-build-and-publish.yml
@@ -104,7 +104,7 @@ jobs:
       ios_package_name: 'cmp-ios' # <-- Change this to your ios package name
       desktop_package_name: 'cmp-desktop' # <-- Change this to your desktop package name
       web_package_name: 'cmp-web'   # <-- Change this to your web package name
-      tester_groups: ${{ secrets.FIREBASE_GROUP }} # <-- Change this to your Firebase tester group
+      tester_groups: 'sensei-app-testers' # <-- Change this to your Firebase tester group
       build_ios: ${{ inputs.build_ios }}
       publish_ios: ${{ inputs.publish_ios }}
     secrets:


### PR DESCRIPTION
Update the multi-platform build and publish workflow to use a specific Firebase tester group `sensei-app-testers` instead of reading from secrets.

Jira Link - [SOB-4](https://mobilebytesensei.atlassian.net/browse/SOB-4)

[SOB-4]: https://mobilebytesensei.atlassian.net/browse/SOB-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ