### PR TITLE
chore: Sync directories and files from upstream

### DIFF
--- a/.github/workflows/multi-platform-build-and-publish.yml
+++ b/.github/workflows/multi-platform-build-and-publish.yml
@@ -104,7 +104,7 @@ jobs:
       ios_package_name: 'cmp-ios' # <-- Change this to your ios package name
       desktop_package_name: 'cmp-desktop' # <-- Change this to your desktop package name
       web_package_name: 'cmp-web'   # <-- Change this to your web package name
-      tester_groups: 'sensei-app-testers' # <-- Change this to your Firebase tester group
+      tester_groups: 'mobile-wallet-testing' # <-- Change this to your Firebase tester group
       build_ios: ${{ inputs.build_ios }}
       publish_ios: ${{ inputs.publish_ios }}
     secrets:

--- a/.run/cmp-android.run.xml
+++ b/.run/cmp-android.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="cmp-android" type="AndroidRunConfigurationType" factoryName="Android App" activateToolWindowBeforeRun="false">
-    <module name="super-order-billing.cmp-android" />
+    <module name="kmp-project-template.cmp-android" />
     <option name="ANDROID_RUN_CONFIGURATION_SCHEMA_VERSION" value="1" />
     <option name="DEPLOY" value="true" />
     <option name="DEPLOY_APK_FROM_BUNDLE" value="false" />

--- a/cmp-android/build.gradle.kts
+++ b/cmp-android/build.gradle.kts
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024 Android Byte Sensei
+ * Copyright 2024 Mifos Initiative
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * See https://github.com/androidbytesensei/super-order-billing/blob/dev/LICENSE
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
  */
 import org.convention.AppBuildType
 import org.convention.dynamicVersion

--- a/cmp-android/lint-baseline.xml
+++ b/cmp-android/lint-baseline.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright 2024 Android Byte Sensei
+    Copyright 2024 Mifos Initiative
 
     This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    See https://github.com/androidbytesensei/super-order-billing/blob/dev/LICENSE
+    See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
 -->
 <issues format="6" by="lint 8.5.2" type="baseline" client="gradle" dependencies="true" name="AGP (8.5.2)" variant="all" version="8.5.2">
 

--- a/cmp-android/src/main/AndroidManifest.xml
+++ b/cmp-android/src/main/AndroidManifest.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright 2024 Android Byte Sensei
+    Copyright 2024 Mifos Initiative
 
     This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0.
     If a copy of the MPL was not distributed with this file,
     You can obtain one at https://mozilla.org/MPL/2.0/.
 
-    See https://github.com/androidbytesensei/super-order-billing/blob/dev/LICENSE
+    See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
 -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">

--- a/cmp-android/src/main/kotlin/cmp/android/app/AndroidApp.kt
+++ b/cmp-android/src/main/kotlin/cmp/android/app/AndroidApp.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024 Android Byte Sensei
+ * Copyright 2024 Mifos Initiative
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * See See https://github.com/androidbytesensei/super-order-billing/blob/dev/LICENSE
+ * See See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
  */
 package cmp.android.app
 

--- a/cmp-android/src/main/kotlin/cmp/android/app/MainActivity.kt
+++ b/cmp-android/src/main/kotlin/cmp/android/app/MainActivity.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024 Android Byte Sensei
+ * Copyright 2024 Mifos Initiative
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * See See https://github.com/androidbytesensei/super-order-billing/blob/dev/LICENSE
+ * See See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
  */
 package cmp.android.app
 
@@ -16,7 +16,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
 import cmp.shared.SharedApp
-import com.sensei.order.billing.core.ui.utils.ShareUtils
+import org.mifos.core.ui.utils.ShareUtils
 
 /**
  * Main activity class.

--- a/cmp-desktop/src/jvmMain/kotlin/main.kt
+++ b/cmp-desktop/src/jvmMain/kotlin/main.kt
@@ -40,7 +40,7 @@ fun main() {
         Window(
             onCloseRequest = ::exitApplication,
             state = windowState,
-            title = "Super Order Billing",
+            title = "DesktopApp",
         ) {
             // Sets the content of the window.
             SharedApp()

--- a/cmp-shared/build.gradle.kts
+++ b/cmp-shared/build.gradle.kts
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024 Android Byte Sensei
+ * Copyright 2024 Mifos Initiative
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * See https://github.com/androidbytesensei/super-order-billing/blob/dev/LICENSE
+ * See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
  */
 
 plugins {

--- a/cmp-shared/src/commonMain/kotlin/cmp/shared/SharedApp.kt
+++ b/cmp-shared/src/commonMain/kotlin/cmp/shared/SharedApp.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024 Android Byte Sensei
+ * Copyright 2024 Mifos Initiative
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * See See https://github.com/androidbytesensei/super-order-billing/blob/dev/LICENSE
+ * See See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
  */
 package cmp.shared
 

--- a/cmp-shared/src/commonMain/kotlin/cmp/shared/utils/KoinExt.kt
+++ b/cmp-shared/src/commonMain/kotlin/cmp/shared/utils/KoinExt.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2025 Android Byte Sensei
+ * Copyright 2025 Mifos Initiative
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * See See https://github.com/androidbytesensei/super-order-billing/blob/dev/LICENSE
+ * See See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
  */
 package cmp.shared.utils
 

--- a/cmp-shared/src/nativeMain/kotlin/org/mifos/shared/ViewController.kt
+++ b/cmp-shared/src/nativeMain/kotlin/org/mifos/shared/ViewController.kt
@@ -1,11 +1,11 @@
 /*
- * Copyright 2024 Android Byte Sensei
+ * Copyright 2024 Mifos Initiative
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  *
- * See See https://github.com/androidbytesensei/super-order-billing/blob/dev/LICENSE
+ * See See https://github.com/openMF/kmp-project-template/blob/main/LICENSE
  */
 package org.mifos.shared
 

--- a/cmp-web/src/wasmJsMain/kotlin/Main.kt
+++ b/cmp-web/src/wasmJsMain/kotlin/Main.kt
@@ -37,7 +37,7 @@ fun main() {
      * This window uses the canvas element with the ID "ComposeTarget" and has the title "WebApp".
      */
     CanvasBasedWindow(
-        title = "Super Order Billing", // Window title
+        title = "WebApp", // Window title
         canvasElementId = "ComposeTarget", // The canvas element where the Compose UI will be rendered
     ) {
         /*


### PR DESCRIPTION
Automated sync of directories and files from upstream repository.

Changes included in this sync:

Directories:
- cmp-android (excluding src/main/res, dependencies, ic_launcher-playstore.png, google-services.json)
- cmp-desktop (excluding icons)
- cmp-ios (excluding iosApp/Assets.xcassets)
- cmp-web (excluding src/jsMain/resources, src/wasmJsMain/resources)
- cmp-shared
- build-logic
- fastlane
- scripts
- config
- .github
- .run

Files:
- Gemfile
- Gemfile.lock
- ci-prepush.bat
- ci-prepush.sh

Workflow run: https://github.com/androidbytesensei/super-order-billing/actions/runs/12967370795